### PR TITLE
Add missing "unrecognized" enum to GatewayRejectionReason

### DIFF
--- a/src/main/java/com/braintreegateway/Transaction.java
+++ b/src/main/java/com/braintreegateway/Transaction.java
@@ -43,7 +43,8 @@ public class Transaction {
         AVS("avs"),
         AVS_AND_CVV("avs_and_cvv"),
         CVV("cvv"),
-        DUPLICATE("duplicate");
+        DUPLICATE("duplicate"),
+        UNRECOGNIZED("unrecognized");
 
         private final String name;
 


### PR DESCRIPTION
Add new GatewayRejectionReason "unrecognized".

The BrainTree Server is now returning a new "GatewayRejectionReason" called "unrecognized" is not being
handled by the latest java braintree api.

java.lang.IllegalArgumentException: No enum const class com.braintreegateway.Transaction$GatewayRejectionReason.UNRECOGNIZED
        at java.lang.Enum.valueOf(Enum.java:214) ~[na:1.6.0_24]
        at com.braintreegateway.util.EnumUtils.findByName(EnumUtils.java:12) ~[braintree-java-2.24.0.jar:na]
        at com.braintreegateway.Transaction.<init>(Transaction.java:155) ~[braintree-java-2.24.0.jar:na]
