### PR TITLE
Include Coinbase accounts in customers' payment methods

### DIFF
--- a/src/main/java/com/braintreegateway/Customer.java
+++ b/src/main/java/com/braintreegateway/Customer.java
@@ -136,6 +136,7 @@ public class Customer {
         paymentMethods.addAll(getPayPalAccounts());
         paymentMethods.addAll(getApplePayCards());
         paymentMethods.addAll(getAndroidPayCards());
+        paymentMethods.addAll(getCoinbaseAccounts());
         return Collections.unmodifiableList(paymentMethods);
     }
 


### PR DESCRIPTION
This change includes any coinbase accounts amongst the payment methods returned from `Customer#getPaymentMethods`