### PR TITLE
Moved method getSubscriptions to PaymentMethod interface

### DIFF
--- a/src/main/java/com/braintreegateway/EuropeBankAccount.java
+++ b/src/main/java/com/braintreegateway/EuropeBankAccount.java
@@ -2,6 +2,7 @@ package com.braintreegateway;
 
 import com.braintreegateway.util.NodeWrapper;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class EuropeBankAccount implements PaymentMethod {
@@ -70,5 +71,9 @@ public class EuropeBankAccount implements PaymentMethod {
 
     public String getCustomerId() {
         return customerId;
+    }
+
+    public List<Subscription> getSubscriptions() {
+        return Collections.EMPTY_LIST;
     }
 }

--- a/src/main/java/com/braintreegateway/PaymentMethod.java
+++ b/src/main/java/com/braintreegateway/PaymentMethod.java
@@ -1,9 +1,12 @@
 package com.braintreegateway;
 
+import java.util.List;
+
 public interface PaymentMethod {
 
     String getToken();
     boolean isDefault();
     String getImageUrl();
     String getCustomerId();
+    List<Subscription> getSubscriptions();
 }

--- a/src/main/java/com/braintreegateway/UnknownPaymentMethod.java
+++ b/src/main/java/com/braintreegateway/UnknownPaymentMethod.java
@@ -2,6 +2,9 @@ package com.braintreegateway;
 
 import com.braintreegateway.util.NodeWrapper;
 
+import java.util.Collections;
+import java.util.List;
+
 public class UnknownPaymentMethod implements PaymentMethod {
     private String token;
     private String customerId;
@@ -27,5 +30,9 @@ public class UnknownPaymentMethod implements PaymentMethod {
 
     public String getCustomerId() {
         return customerId;
+    }
+
+    public List<Subscription> getSubscriptions() {
+        return Collections.EMPTY_LIST;
     }
 }


### PR DESCRIPTION
By having getSubscriptions method in the interfacet, it is possible to get all subscriptions of a user easily instead of having to cast for each and every payment method implementation.