### PR TITLE
Update jackson-qr-objects to 2.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.103.1
+* Update `jackson-jr` to v2.9.9 to fix CVE-2018-11307
+
 ## 2.103.0
 * Add `getUniqueNumberIdentifier` to `CustomActionsPaymentMethodDetails`
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
           <groupId>com.fasterxml.jackson.jr</groupId>
           <artifactId>jackson-jr-objects</artifactId>
-          <version>2.9.5</version>
+          <version>2.9.9</version>
         </dependency>
         <dependency>
           <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
# Summary
Bumps jackson-qr-objects to v2.9.9.

There's an open CVE on the older version of Jackson: https://nvd.nist.gov/vuln/detail/CVE-2018-11307

The wildcard pattern matches the jackson-jr-objects library used by braintree_java. I'm not sure if it's meant to be included and, if it is, I don't think there's any security issue with the usage of the older version as braintree_java only deserializes via `JSON.std.mapFrom(...)`, but would be nice to have this closed out anyway.

# Checklist

- [X] Added changelog entry
- [X] Ran unit tests (`mvn verify -DskipITs`)
