### PR TITLE
Feature/enable custom http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Add `http` setter to `BraintreeGateway`
+
 ## 2.105.0
 * Add `merchantAccountId` setter to `ThreeDSecureLookupRequest`
 

--- a/src/main/java/com/braintreegateway/BraintreeGateway.java
+++ b/src/main/java/com/braintreegateway/BraintreeGateway.java
@@ -79,6 +79,13 @@ public class BraintreeGateway {
         this.graphQLClient = new GraphQLClient(configuration);
     }
 
+    public Http getHttp() {
+        return http;
+    }
+    public void setHttp(Http http) {
+        this.http = http;
+    }
+
     /**
      * Returns a BraintreeGateway specifically for Partner usage. Unless you are a partner, use the regular constructor instead.
      *

--- a/src/main/java/com/braintreegateway/BraintreeGateway.java
+++ b/src/main/java/com/braintreegateway/BraintreeGateway.java
@@ -79,9 +79,6 @@ public class BraintreeGateway {
         this.graphQLClient = new GraphQLClient(configuration);
     }
 
-    public Http getHttp() {
-        return http;
-    }
     public void setHttp(Http http) {
         this.http = http;
     }


### PR DESCRIPTION
# Summary

- Add `http` setter to `BraintreeGateway`

This allows for a custom http implementation. A custom implementation gives us more control over how http client connections are handled.

# Checklist

- [yes] Added changelog entry
- [yes] Ran unit tests (`mvn verify -DskipITs`)
