### PR TITLE
Make `code` field final

### DIFF
--- a/src/main/java/com/braintreegateway/ValidationErrorCode.java
+++ b/src/main/java/com/braintreegateway/ValidationErrorCode.java
@@ -706,7 +706,7 @@ public enum ValidationErrorCode {
     @Deprecated
     UNKOWN_VALIDATION_ERROR("");
 
-    public String code;
+    public final String code;
 
     private ValidationErrorCode(String code) {
         this.code = code;

--- a/src/main/java/com/braintreegateway/ValidationErrorCode.java
+++ b/src/main/java/com/braintreegateway/ValidationErrorCode.java
@@ -706,7 +706,8 @@ public enum ValidationErrorCode {
     @Deprecated
     UNKOWN_VALIDATION_ERROR("");
 
-    public final String code;
+    // NEXT_MAJOR_VERSION this should be `final` to prevent end users from modifying it
+    public String code;
 
     private ValidationErrorCode(String code) {
         this.code = code;


### PR DESCRIPTION
The `code` field in the ValidationErrorCode enum was public but not final. This could lead to a user accidentally changing the value of this field.