### PR TITLE
ThreeDSecureInfo gets auth data from correct XML node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.0
+* Fix bug in `ThreeDSecureInfo` loading auth data from wrong XML node
+
 ## 3.3.0
 * Add `acquirerReferenceNumber` to `Transaction`
 * Add `billingAgreementId` to `PayPalDetails`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.4.0
+## unreleased
 * Fix bug in `ThreeDSecureInfo` loading auth data from wrong XML node
 
 ## 3.3.0

--- a/src/main/java/com/braintreegateway/ThreeDSecureInfo.java
+++ b/src/main/java/com/braintreegateway/ThreeDSecureInfo.java
@@ -40,7 +40,7 @@ public class ThreeDSecureInfo {
         if (threeDSecureLookupInfoNode != null && !threeDSecureLookupInfoNode.isBlank()) {
             threeDSecureLookupInfo = new ThreeDSecureLookupInfo(threeDSecureLookupInfoNode);
         }
-        NodeWrapper threeDSecureAuthenticateInfoNode = node.findFirst("authenticate");
+        NodeWrapper threeDSecureAuthenticateInfoNode = node.findFirst("authentication");
         if (threeDSecureAuthenticateInfoNode != null && !threeDSecureAuthenticateInfoNode.isBlank()) {
             threeDSecureAuthenticateInfo = new ThreeDSecureAuthenticateInfo(threeDSecureAuthenticateInfoNode);
         }
@@ -65,7 +65,7 @@ public class ThreeDSecureInfo {
         if (threeDSecureLookupInfoMap != null) {
             threeDSecureLookupInfo = new ThreeDSecureLookupInfo(threeDSecureLookupInfoMap);
         }
-        Map<String, Object> threeDSecureAuthenticateInfoMap = (Map) map.get("authenticate");
+        Map<String, Object> threeDSecureAuthenticateInfoMap = (Map) map.get("authentication");
         if (threeDSecureAuthenticateInfoMap != null) {
             threeDSecureAuthenticateInfo = new ThreeDSecureAuthenticateInfo(threeDSecureAuthenticateInfoMap);
         }


### PR DESCRIPTION
# Summary
Hello 👋 When trying to construct a [`PaymentMethodNonce`](https://github.com/braintree/braintree_java/blob/d2a113d2928541b1f48d575c3312978092aeb1a1/src/main/java/com/braintreegateway/PaymentMethodNonce.java#L5-L5) from the XML response in [`PaymentMethodNonceGateway::find`](https://github.com/braintree/braintree_java/blob/d2a113d2928541b1f48d575c3312978092aeb1a1/src/main/java/com/braintreegateway/PaymentMethodNonceGateway.java#L25-L28) the constructor for [`ThreeDSecureInfo`](https://github.com/braintree/braintree_java/blob/d2a113d2928541b1f48d575c3312978092aeb1a1/src/main/java/com/braintreegateway/ThreeDSecureInfo.java#L23-L23) is looking in the wrong place for the 3DS info. It's trying to load it from a node called `authenticate` when it's actually called `authentication`. The XML looks like
```
<?xml version="1.0" encoding="UTF-8"?>
<payment-method-nonce>
  <three-d-secure-info>
    <authentication>
      <trans-status nil="true"/>
      <trans-status-reason nil="true"/>
    </authentication>
  </three-d-secure-info>
</payment-method-nonce>
```


# Checklist
- [x] Added changelog entry
- [x] Ran unit tests (`mvn verify -DskipITs`)
![image](https://user-images.githubusercontent.com/3372954/99800617-8e3f4a80-2b2c-11eb-881f-597d42a87e1e.png)


<!-- **For Braintree Developers only, don't forget:**
- [ ] Does this change require work to be done to the GraphQL API? If you have questions check with the GraphQL team.
- [ ] Add & Run integration tests -->
