### PR TITLE
Crypto#secureCompare : use the primitive type as the return value could not be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+* Fix Crypto#secureCompare to use the primitive type as the return value could not be null
+
 ## 3.3.0
 * Add `acquirerReferenceNumber` to `Transaction`
 * Add `billingAgreementId` to `PayPalDetails`

--- a/src/main/java/com/braintreegateway/util/Crypto.java
+++ b/src/main/java/com/braintreegateway/util/Crypto.java
@@ -1,7 +1,7 @@
 package com.braintreegateway.util;
 
 public class Crypto {
-    public Boolean secureCompare(String left, String right) {
+    public boolean secureCompare(String left, String right) {
         if (left == null || right == null || (left.length() != right.length())) {
             return false;
         }


### PR DESCRIPTION
# Summary
 Fix Crypto#secureCompare signature to use the primitive type as the return value could not be null

# Checklist

- [X] Added changelog entry
- [X] Ran unit tests (`mvn verify -DskipITs`)
