### PR TITLE
Re-use patterns, Avoid compiling / creating pattern when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+* Patter / regexp usage optimization : Re-use patterns / Avoid compiling / creating patterns when not needed
+
 ## 3.3.0
 * Add `acquirerReferenceNumber` to `Transaction`
 * Add `billingAgreementId` to `PayPalDetails`

--- a/src/main/java/com/braintreegateway/WebhookNotificationGateway.java
+++ b/src/main/java/com/braintreegateway/WebhookNotificationGateway.java
@@ -11,6 +11,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class WebhookNotificationGateway {
+    
+    private static final Pattern PAYLOAD_CHARS_PATTERN = Pattern.compile("[^A-Za-z0-9+=/\n]");
+    private static final Pattern CHALLENGE_CHARS_PATTERN = Pattern.compile("^[a-f0-9]{20,32}$");
+    
     private Configuration configuration;
 
     public WebhookNotificationGateway(Configuration configuration) {
@@ -24,8 +28,7 @@ public class WebhookNotificationGateway {
         if (payload == null) {
             throw new InvalidSignatureException("payload cannot be null");
         }
-        Pattern p = Pattern.compile("[^A-Za-z0-9+=/\n]");
-        Matcher m = p.matcher(payload);
+        Matcher m = PAYLOAD_CHARS_PATTERN.matcher(payload);
         if (m.find()) {
           throw new InvalidSignatureException("payload contains illegal characters");
         }
@@ -64,7 +67,7 @@ public class WebhookNotificationGateway {
     }
 
     public String verify(String challenge) {
-        if (!challenge.matches("^[a-f0-9]{20,32}$")) {
+        if (!CHALLENGE_CHARS_PATTERN.matcher(challenge).matches()) {
           throw new InvalidChallengeException("challenge contains non-hex characters");
         }
         return publicKeySignaturePair(challenge);

--- a/src/main/java/com/braintreegateway/util/EnumUtils.java
+++ b/src/main/java/com/braintreegateway/util/EnumUtils.java
@@ -7,7 +7,7 @@ public class EnumUtils {
             return null;
         }
         try {
-            return Enum.valueOf(enumType, name.toUpperCase().replaceAll(" ", "_"));
+            return Enum.valueOf(enumType, name.toUpperCase().replace(' ', '_'));
         } catch (IllegalArgumentException e) {
             return defaultValue;
         }

--- a/src/main/java/com/braintreegateway/util/Http.java
+++ b/src/main/java/com/braintreegateway/util/Http.java
@@ -55,6 +55,11 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class Http {
     public static final String LINE_FEED = "\r\n";
+    private static final Pattern NUMBER_PATTERN = Pattern.compile("<number>(.{6}).+?(.{4})</number>");
+    private static final Pattern START_GROUP_PATTERN = Pattern.compile("(^)", Pattern.MULTILINE);
+    private static final Pattern CVV_PATTERN = Pattern.compile("<cvv>.+?</cvv>");
+    
+    
     private volatile SSLSocketFactory sslSocketFactory;
 
     public enum RequestMethod {
@@ -274,19 +279,17 @@ public class Http {
             return body;
         }
 
-        Pattern regex = Pattern.compile("(^)", Pattern.MULTILINE);
-        Matcher regexMatcher = regex.matcher(body);
+        Matcher regexMatcher = START_GROUP_PATTERN.matcher(body);
         if (regexMatcher.find()) {
             body = regexMatcher.replaceAll("[Braintree] $1");
         }
 
-        regex = Pattern.compile("<number>(.{6}).+?(.{4})</number>");
-        regexMatcher = regex.matcher(body);
+        regexMatcher = NUMBER_PATTERN.matcher(body);
         if (regexMatcher.find()) {
             body = regexMatcher.replaceAll("<number>$1******$2</number>");
         }
 
-        body = body.replaceAll("<cvv>.+?</cvv>", "<cvv>***</cvv>");
+        body = CVV_PATTERN.matcher(body).replaceAll("<cvv>***</cvv>");
 
         return body;
     }

--- a/src/main/java/com/braintreegateway/util/StringUtils.java
+++ b/src/main/java/com/braintreegateway/util/StringUtils.java
@@ -4,8 +4,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.*;
+import java.util.regex.Pattern;
 
 public class StringUtils {
+    
+    private static final Pattern CONTIGUOUS_UPPERCASE = Pattern.compile("([A-Z]+)([A-Z][a-z])");
+    private static final Pattern CAMEL_CASE = Pattern.compile("([a-z])([A-Z])");
+    
     public static <T> String classToXMLName(Class<T> klass) {
         return dasherize(klass.getSimpleName()).toLowerCase();
     }
@@ -15,9 +20,10 @@ public class StringUtils {
             return null;
         }
 
-        return str.replaceAll("([A-Z]+)([A-Z][a-z])", "$1-$2")
-            .replaceAll("([a-z])([A-Z])", "$1-$2")
-            .replaceAll("_", "-")
+        str = CONTIGUOUS_UPPERCASE.matcher(str).replaceAll("$1-$2");
+        str = CAMEL_CASE.matcher(str).replaceAll("$1-$2");
+        
+        return str.replace('_', '-')
             .toLowerCase();
     }
 
@@ -50,9 +56,10 @@ public class StringUtils {
             return null;
         }
 
-        return str.replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
-            .replaceAll("([a-z])([A-Z])", "$1_$2")
-            .replaceAll("-", "_")
+        str = CONTIGUOUS_UPPERCASE.matcher(str).replaceAll("$1_$2");
+        str = CAMEL_CASE.matcher(str).replaceAll("$1_$2");
+        
+        return str.replace('-', '_')
             .toLowerCase();
     }
 

--- a/src/test/java/com/braintreegateway/unittest/util/EnumUtilsTest.java
+++ b/src/test/java/com/braintreegateway/unittest/util/EnumUtilsTest.java
@@ -41,6 +41,11 @@ public class EnumUtilsTest {
         assertEquals(Transaction.Status.UNRECOGNIZED, EnumUtils.findByName(Transaction.Status.class, "blah", Transaction.Status.UNRECOGNIZED));
         assertEquals(Transaction.Type.UNRECOGNIZED, EnumUtils.findByName(Transaction.Type.class, "blah", Transaction.Type.UNRECOGNIZED));
     }
+    
+    @Test
+    public void findByNameWithWhiteSpace() {
+        assertEquals(Transaction.Status.AUTHORIZATION_EXPIRED, EnumUtils.findByName(Transaction.Status.class, "AUTHORIZATION EXPIRED", Transaction.Status.UNRECOGNIZED));
+    }
 
     @Test
     public void findByToString_returnsEnumWithExactMatch() {


### PR DESCRIPTION
# Summary
Re-use patterns
Avoid compiling / creating pattern when not needed (String#replaceAll)
No need to do the compilation each time : Pattern are thread safe

Already covered by tests except for EnumUtils where a test was missing
(added)


# Checklist

- [X] Added changelog entry
- [X] Ran unit tests (`mvn verify -DskipITs`)
