### PR TITLE
avoid allocating memory / constructing object if the message is not going to be logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.1
+* avoid allocating memory / constructing object if the message is not going to be logged
+
 ## 3.3.0
 * Add `acquirerReferenceNumber` to `Transaction`
 * Add `billingAgreementId` to `PayPalDetails`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
-## 3.3.1
-* avoid allocating memory / constructing object if the message is not going to be logged
-
-## 3.3.0
+## unreleased
+* Avoid allocating memory / constructing object if the message is not going to be logged
 * Avoid multiple node traversal in webhooks parsing
 
 ## 3.3.0

--- a/src/main/java/com/braintreegateway/util/Http.java
+++ b/src/main/java/com/braintreegateway/util/Http.java
@@ -114,7 +114,8 @@ public class Http {
 
         try {
             Logger logger = configuration.getLogger();
-            if (postBody != null) {
+            
+            if (postBody != null && logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, formatSanitizeBodyForLog(postBody));
             }
 
@@ -160,15 +161,20 @@ public class Http {
 
                 response = StringUtils.inputStreamToString(responseStream);
 
-                logger.log(Level.INFO,
+                if (logger.isLoggable(Level.INFO)) {
+                    logger.log(Level.INFO,
                            "[Braintree] [{0}]] {1} {2}",
                            new Object[]{getCurrentTime(), requestMethod.toString(), url});
-                logger.log(Level.FINE,
-                           "[Braintree] [{0}] {1} {2} {3}",
-                           new Object[]{getCurrentTime(), requestMethod.toString(), url, connection.getResponseCode()});
-
-                if (response != null) {
-                    logger.log(Level.FINE, formatSanitizeBodyForLog(response));
+                }
+                
+                if (logger.isLoggable(Level.FINE)) {
+                    logger.log(Level.FINE,
+                            "[Braintree] [{0}] {1} {2} {3}",
+                            new Object[]{getCurrentTime(), requestMethod.toString(), url, connection.getResponseCode()});
+                    
+                    if (response != null) {
+                        logger.log(Level.FINE, formatSanitizeBodyForLog(response));
+                    }
                 }
 
                 if (response == null || response.trim().equals("")) {

--- a/src/main/java/com/braintreegateway/util/Http.java
+++ b/src/main/java/com/braintreegateway/util/Http.java
@@ -114,7 +114,7 @@ public class Http {
 
         try {
             Logger logger = configuration.getLogger();
-            
+
             if (postBody != null && logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, formatSanitizeBodyForLog(postBody));
             }
@@ -166,12 +166,12 @@ public class Http {
                            "[Braintree] [{0}]] {1} {2}",
                            new Object[]{getCurrentTime(), requestMethod.toString(), url});
                 }
-                
+
                 if (logger.isLoggable(Level.FINE)) {
                     logger.log(Level.FINE,
                             "[Braintree] [{0}] {1} {2} {3}",
                             new Object[]{getCurrentTime(), requestMethod.toString(), url, connection.getResponseCode()});
-                    
+
                     if (response != null) {
                         logger.log(Level.FINE, formatSanitizeBodyForLog(response));
                     }


### PR DESCRIPTION
# Summary
 avoid allocating memory / constructing object if the message is not going to be logged

# Checklist

- [X] Added changelog entry
- [X] Ran unit tests (`mvn verify -DskipITs`)
