### PR TITLE
Test Fix: Fix tests that can unintentionally fail in toXMLIncludesAllElements() and serializesPriorAuthenticationDetails() due to local time conversion

### DIFF
--- a/src/test/java/com/braintreegateway/unittest/ThreeDSecureLookupRequestTest.java
+++ b/src/test/java/com/braintreegateway/unittest/ThreeDSecureLookupRequestTest.java
@@ -10,6 +10,7 @@ import com.braintreegateway.ThreeDSecureLookupPriorAuthenticationDetails;
 import java.util.Map;
 import com.fasterxml.jackson.jr.ob.JSON;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -214,6 +215,7 @@ public class ThreeDSecureLookupRequestTest {
             "}";
 
         Calendar authTime = Calendar.getInstance();
+        authTime.setTimeZone(TimeZone.getTimeZone("UTC"));
         authTime.set(2024, Calendar.FEBRUARY, 10, 22, 45, 30);
 
         ThreeDSecureLookupPriorAuthenticationDetails priorAuthenticationDetails = new ThreeDSecureLookupPriorAuthenticationDetails()

--- a/src/test/java/com/braintreegateway/unittest/TransactionIndustryRequestTest.java
+++ b/src/test/java/com/braintreegateway/unittest/TransactionIndustryRequestTest.java
@@ -2,6 +2,7 @@ package com.braintreegateway.unittest;
 
 import java.io.IOException;
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import com.braintreegateway.TransactionRequest;
 import com.braintreegateway.TransactionIndustryRequest;
@@ -21,6 +22,7 @@ public class TransactionIndustryRequestTest {
         TransactionIndustryRequest request = new TransactionIndustryRequest(txnRequest);
 
         Calendar arrivalDate = Calendar.getInstance();
+        arrivalDate.setTimeZone(TimeZone.getTimeZone("UTC"));
         arrivalDate.set(2023, Calendar.FEBRUARY, 10, 22, 45, 30);
 
         request.industryType(Transaction.IndustryType.TRAVEL_FLIGHT)


### PR DESCRIPTION
The actual date in the output has been converted to the local time zone when compared to the expected date. As a result, these tests can fail depending on where they are run.

Below are examples where it fails under [NonDex](https://github.com/TestingResearchIllinois/NonDex) on [line 49 in TransactionIndustryRequestTest.java](https://github.com/braintree/braintree_java/blob/f18f7ba72fd2b25a04e4cafedd82b037ce9c539a/src/test/java/com/braintreegateway/unittest/TransactionIndustryRequestTest.java#L49) and on [line 235 in ThreeDSecureLookupRequestTest.java](https://github.com/braintree/braintree_java/blob/f18f7ba72fd2b25a04e4cafedd82b037ce9c539a/src/test/java/com/braintreegateway/unittest/ThreeDSecureLookupRequestTest.java#L235)
(My timezone is CDT)

<details>

<summary>Click on to see more details on the error message when running both tests</summary>

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.braintreegateway.unittest.TransactionIndustryRequestTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.438 s <<< FAILURE! - in com.braintreegateway.unittest.TransactionIndustryRequestTest
[ERROR] toXMLIncludesAllElements  Time elapsed: 0.397 s  <<< ERROR!
junit.framework.AssertionFailedError: 
org.custommonkey.xmlunit.Diff
[not identical] Expected sequence of child nodes '1' but was '3' - comparing <arrivalDate...> at /industry[1]/data[1]/arrivalDate[1] to <arrivalDate...> at /industry[1]/data[1]/arrivalDate[1]

[different] Expected text value '2023-02-10T22:45:30Z' but was '2023-02-11T04:45:30Z' - comparing <arrivalDate ...>2023-02-10T22:45:30Z</arrivalDate> at /industry[1]/data[1]/arrivalDate[1]/text()[1] to <arrivalDate ...>2023-02-11T04:45:30Z</arrivalDate> at /industry[1]/data[1]/arrivalDate[1]/text()[1]

        at com.braintreegateway.unittest.TransactionIndustryRequestTest.toXMLIncludesAllElements(TransactionIndustryRequestTest.java:49)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   TransactionIndustryRequestTest.toXMLIncludesAllElements:49 org.custommonkey.xmlunit.Diff
[not identical] Expected sequence of child nodes '1' but was '3' - comparing <arrivalDate...> at /industry[1]/data[1]/arrivalDate[1] to <arrivalDate...> at /industry[1]/data[1]/arrivalDate[1]

[different] Expected text value '2023-02-10T22:45:30Z' but was '2023-02-11T04:45:30Z' - comparing <arrivalDate ...>2023-02-10T22:45:30Z</arrivalDate> at /industry[1]/data[1]/arrivalDate[1]/text()[1] to <arrivalDate ...>2023-02-11T04:45:30Z</arrivalDate> at /industry[1]/data[1]/arrivalDate[1]/text()[1]

[INFO] 
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO] 

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.braintreegateway.unittest.ThreeDSecureLookupRequestTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.295 s <<< FAILURE! - in com.braintreegateway.unittest.ThreeDSecureLookupRequestTest
[ERROR] serializesPriorAuthenticationDetails  Time elapsed: 0.275 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at com.braintreegateway.unittest.ThreeDSecureLookupRequestTest.serializesPriorAuthenticationDetails(ThreeDSecureLookupRequestTest.java:235)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ThreeDSecureLookupRequestTest.serializesPriorAuthenticationDetails:235 expected: <true> but was: <false>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO]
```

</details>

To reproduce both, run these at the root directory:

```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex     -Dtest=com/braintreegateway/unittest/TransactionIndustryRequestTest#toXMLIncludesAllElements
```

```
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex     -Dtest=com/braintreegateway/unittest/ThreeDSecureLookupRequestTest#serializesPriorAuthenticationDetails
```

The log output for both tests can be found here for your reference:
[mvn-nondex-2-1729185623.log](https://github.com/user-attachments/files/17416580/mvn-nondex-2-1729185623.log)
[mvn-nondex-1729184306.log](https://github.com/user-attachments/files/17416581/mvn-nondex-1729184306.log)

**To resolve this**, we need to ensure that the conversion to the local time zone doesn't occur when comparing with the expected date. To achieve this, we can explicitly set the Calendar's time zone to UTC.

After applying the fix, the test should now pass with NonDex as expected:

```
[INFO] *********
[INFO] All tests pass without NonDex shuffling
[INFO] ####################
[INFO] Across all seeds:
[INFO] Test results can be found at: 
[INFO] file:///home/jakew4/braintree_java/.nondex/o+N2zAWYfjR4hoCKwtDY9gT7hwenXEQae4EH6eFm3FA=/test_results.html
[INFO] [NonDex] The id of this run is: o+N2zAWYfjR4hoCKwtDY9gT7hwenXEQae4EH6eFm3FA=
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  21.764 s
[INFO] Finished at: 2024-10-17T12:29:20-05:00
[INFO] ------------------------------------------------------------------------
```

Please let me know if this approach works for you. If not, I'm happy to discuss alternatives and am willing to spend more time to address the test in the way you'd prefer. Thank you!